### PR TITLE
feat(pot): create POT detection feature

### DIFF
--- a/src/anomalytics/__init__.py
+++ b/src/anomalytics/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.1.0"
 
-__all__ = ["get_anomaly_score", "get_exceedance_peaks_over_threshold", "read_ts", "set_time_window"]
+__all__ = ["get_anomaly", "get_anomaly_score", "get_exceedance_peaks_over_threshold", "read_ts", "set_time_window"]
 
-from anomalytics.stats import get_anomaly_score, get_exceedance_peaks_over_threshold
+from anomalytics.stats import get_anomaly, get_anomaly_score, get_exceedance_peaks_over_threshold
 from anomalytics.time_series import read_ts
 from anomalytics.time_windows import set_time_window

--- a/src/anomalytics/__init__.py
+++ b/src/anomalytics/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.1.0"
 
-__all__ = ["fit_exceedance", "get_exceedance_peaks_over_threshold", "read_ts", "set_time_window"]
+__all__ = ["get_anomaly_score", "get_exceedance_peaks_over_threshold", "read_ts", "set_time_window"]
 
-from anomalytics.stats import fit_exceedance, get_exceedance_peaks_over_threshold
+from anomalytics.stats import get_anomaly_score, get_exceedance_peaks_over_threshold
 from anomalytics.time_series import read_ts
 from anomalytics.time_windows import set_time_window

--- a/src/anomalytics/stats/__init__.py
+++ b/src/anomalytics/stats/__init__.py
@@ -1,7 +1,13 @@
-__all__ = ["get_anomaly_score", "get_threshold_peaks_over_threshold", "get_exceedance_peaks_over_threshold"]
+__all__ = [
+    "get_anomaly_score",
+    "get_anomaly_threshold",
+    "get_threshold_peaks_over_threshold",
+    "get_exceedance_peaks_over_threshold",
+]
 
 from anomalytics.stats.peaks_over_threshold import (
     get_anomaly_score,
+    get_anomaly_threshold,
     get_exceedance_peaks_over_threshold,
     get_threshold_peaks_over_threshold,
 )

--- a/src/anomalytics/stats/__init__.py
+++ b/src/anomalytics/stats/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "get_anomaly",
     "get_anomaly_score",
     "get_anomaly_threshold",
     "get_threshold_peaks_over_threshold",
@@ -6,6 +7,7 @@ __all__ = [
 ]
 
 from anomalytics.stats.peaks_over_threshold import (
+    get_anomaly,
     get_anomaly_score,
     get_anomaly_threshold,
     get_exceedance_peaks_over_threshold,

--- a/src/anomalytics/stats/__init__.py
+++ b/src/anomalytics/stats/__init__.py
@@ -1,7 +1,7 @@
-__all__ = ["fit_exceedance", "get_threshold_peaks_over_threshold", "get_exceedance_peaks_over_threshold"]
+__all__ = ["get_anomaly_score", "get_threshold_peaks_over_threshold", "get_exceedance_peaks_over_threshold"]
 
 from anomalytics.stats.peaks_over_threshold import (
-    fit_exceedance,
+    get_anomaly_score,
     get_exceedance_peaks_over_threshold,
     get_threshold_peaks_over_threshold,
 )

--- a/src/anomalytics/stats/peaks_over_threshold.py
+++ b/src/anomalytics/stats/peaks_over_threshold.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import typing
 
@@ -95,7 +94,7 @@ def get_exceedance_peaks_over_threshold(
     return pd.Series(index=ts.index, data=pot_exceedances, name="exceedances")
 
 
-def fit_exceedance(ts: pd.Series, t0: int, gpd_params: typing.Dict) -> pd.Series:
+def get_anomaly_score(ts: pd.Series, t0: int, gpd_params: typing.Dict) -> pd.Series:
     """
     Fit exceedances into generalized pareto distribution to calculate the anomaly score.
 

--- a/src/anomalytics/stats/peaks_over_threshold.py
+++ b/src/anomalytics/stats/peaks_over_threshold.py
@@ -182,8 +182,8 @@ def get_anomaly_threshold(ts: pd.Series, t1: int, q: float = 0.90) -> float:
     t1 : int
         Time window to calculate the quantile score of all anomaly scores.
 
-    gpd_params : dictionary
-        A dictionary used as the storage of the GPD parameters (fitting result).
+    q : float
+        The quantile to use for thresholding, default 0.90.
 
     ## Returns
     ----------
@@ -201,3 +201,37 @@ def get_anomaly_threshold(ts: pd.Series, t1: int, q: float = 0.90) -> float:
         a=t1_anomaly_scores.values,
         q=q,
     )
+
+
+def get_anomaly(ts: pd.Series, t1: int, q: float = 0.90) -> pd.Series:
+    """
+    Detect the anomaloous data by comparing anoamly scores with anomaly threshold.
+
+    ## Parameters
+    -------------
+    ts : pandas.Series
+        The Pandas Series that contains the anomaly scores.
+
+    t1 : int
+        Time window to calculate anomaly threshold and retrieve t2 anomaly scores.
+
+    q : float
+        The quantile to use for thresholding, default 0.90.
+
+    ## Returns
+    ----------
+    anomalies : pandas.Series
+        A Pandas Series that reveals which value is anomalous.
+    """
+    logger.debug(f"detecting anomaly using t1={t1}, q={q}, and `get_anoamly_threshold()` function")
+    if not isinstance(ts, pd.Series):
+        raise TypeError("Invalid value! The `ts` argument must be a Pandas Series")
+
+    anomaly_threshold = get_anomaly_threshold(ts=ts, t1=t1, q=q)
+    t2_anomaly_scores = ts.iloc[t1:]
+    anomalies = t2_anomaly_scores > anomaly_threshold
+
+    logger.debug(
+        f"successfully detecting {len(anomalies[anomalies.values == True].values)} anomalies using anomaly_threshold={anomaly_threshold}"
+    )
+    return pd.Series(index=t2_anomaly_scores.index, data=anomalies.values, name="anomalies")

--- a/src/anomalytics/stats/peaks_over_threshold.py
+++ b/src/anomalytics/stats/peaks_over_threshold.py
@@ -165,6 +165,7 @@ def get_anomaly_score(ts: pd.Series, t0: int, gpd_params: typing.Dict) -> pd.Ser
                 anomaly_score=0.0,
             )
             anomaly_scores.append(0.0)
+
     logger.debug(f"successfully calculating anomaly score")
     return pd.Series(index=ts.index[t0:], data=anomaly_scores, name="anomaly scores")
 
@@ -189,11 +190,13 @@ def get_anomaly_threshold(ts: pd.Series, t1: int, q: float = 0.90) -> float:
     anomaly_threshold : float
         A single float serves as the threshold for anomalous data.
     """
+    logger.debug(f"calculating anomaly threshold using t1={t1}, q={q}, and `numpy.quantile()` function")
     if not isinstance(ts, pd.Series):
         raise TypeError("Invalid value! The `ts` argument must be a Pandas Series")
 
     t1_anomaly_scores = ts[(ts.values > 0) & (ts.values != float("inf"))].iloc[:t1]
 
+    logger.debug(f"successfully calculating anomaly threshold using {q} quantile")
     return np.quantile(
         a=t1_anomaly_scores.values,
         q=q,

--- a/src/anomalytics/stats/peaks_over_threshold.py
+++ b/src/anomalytics/stats/peaks_over_threshold.py
@@ -167,3 +167,34 @@ def get_anomaly_score(ts: pd.Series, t0: int, gpd_params: typing.Dict) -> pd.Ser
             anomaly_scores.append(0.0)
     logger.debug(f"successfully calculating anomaly score")
     return pd.Series(index=ts.index[t0:], data=anomaly_scores, name="anomaly scores")
+
+
+def get_anomaly_threshold(ts: pd.Series, t1: int, q: float = 0.90) -> float:
+    """
+    Claculate a threshold with quantile method used for the comparison to get the anomalies.
+
+    ## Parameters
+    -------------
+    ts : pandas.Series
+        The Pandas Series that contains the anomaly scores.
+
+    t1 : int
+        Time window to calculate the quantile score of all anomaly scores.
+
+    gpd_params : dictionary
+        A dictionary used as the storage of the GPD parameters (fitting result).
+
+    ## Returns
+    ----------
+    anomaly_threshold : float
+        A single float serves as the threshold for anomalous data.
+    """
+    if not isinstance(ts, pd.Series):
+        raise TypeError("Invalid value! The `ts` argument must be a Pandas Series")
+
+    t1_anomaly_scores = ts[(ts.values > 0) & (ts.values != float("inf"))].iloc[:t1]
+
+    return np.quantile(
+        a=t1_anomaly_scores.values,
+        q=q,
+    )

--- a/tests/test_peaks_over_threshold.py
+++ b/tests/test_peaks_over_threshold.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from anomalytics import fit_exceedance, get_exceedance_peaks_over_threshold
+from anomalytics import get_anomaly_score, get_exceedance_peaks_over_threshold
 from anomalytics.stats import get_threshold_peaks_over_threshold
 
 
@@ -46,7 +46,6 @@ class TestPeaksOverThreshold(unittest.TestCase):
         pot_exceedance = get_exceedance_peaks_over_threshold(ts=self.sample_2_ts, t0=5, anomaly_type="low", q=0.10)
         self.assertIsInstance(pot_exceedance, pd.Series)
         self.assertEqual(len(pot_exceedance), len(self.sample_2_ts))
-        # Check if all exceedances are non-negative
         self.assertTrue((pot_exceedance >= 0).all())
 
     def test_invalid_anomaly_type_in_exceedance_extraction_function(self):
@@ -66,7 +65,7 @@ class TestPeaksOverThreshold(unittest.TestCase):
         t0 = 10
         gpd_params: dict = {}
         exceedances = get_exceedance_peaks_over_threshold(ts=ts, t0=t0, anomaly_type="high", q=0.9)
-        anomaly_scores = fit_exceedance(ts=exceedances, t0=t0, gpd_params=gpd_params)
+        anomaly_scores = get_anomaly_score(ts=exceedances, t0=t0, gpd_params=gpd_params)
 
         self.assertIsInstance(anomaly_scores, pd.Series)
         self.assertEqual(len(anomaly_scores), len(ts.values) - t0)
@@ -77,14 +76,14 @@ class TestPeaksOverThreshold(unittest.TestCase):
         gpd_params: dict = {}
 
         with self.assertRaises(TypeError):
-            fit_exceedance(ts="not a series", t0=t0, gpd_params=gpd_params)
+            get_anomaly_score(ts="not a series", t0=t0, gpd_params=gpd_params)
 
     def test_fit_exceedance_with_invalid_t0(self):
         ts = pd.Series(np.random.rand(100) * 2, index=pd.date_range("2020-01-01", periods=100))
         gpd_params: dict = {}
 
         with self.assertRaises(ValueError):
-            fit_exceedance(ts=ts, t0=None, gpd_params=gpd_params)  # type: ignore
+            get_anomaly_score(ts=ts, t0=None, gpd_params=gpd_params)  # type: ignore
 
     def tearDown(self) -> None:
         return super().tearDown()

--- a/tests/test_peaks_over_threshold.py
+++ b/tests/test_peaks_over_threshold.py
@@ -101,5 +101,18 @@ class TestPeaksOverThreshold(unittest.TestCase):
         with self.assertRaises(TypeError):
             get_anomaly_threshold(ts="not a series", t1=t1, q=q)
 
+    def test_confirm_correct_quantile_calculation_for_anomaly_threshold(self):
+        ts = pd.Series(
+            [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], index=pd.date_range("2020-01-01", periods=10)
+        )
+        t1 = 5
+        q = 0.90
+        t1_ts = ts.iloc[:t1]
+
+        expected_anomaly_threshold = np.quantile(a=t1_ts.values, q=q)
+        anomaly_threshold = get_anomaly_threshold(ts=ts, t1=t1, q=q)
+
+        self.assertEqual(anomaly_threshold, expected_anomaly_threshold)
+
     def tearDown(self) -> None:
         return super().tearDown()

--- a/tests/test_peaks_over_threshold.py
+++ b/tests/test_peaks_over_threshold.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from anomalytics import get_anomaly_score, get_exceedance_peaks_over_threshold
-from anomalytics.stats import get_threshold_peaks_over_threshold
+from anomalytics.stats import get_anomaly_threshold, get_threshold_peaks_over_threshold
 
 
 class TestPeaksOverThreshold(unittest.TestCase):
@@ -84,6 +84,22 @@ class TestPeaksOverThreshold(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             get_anomaly_score(ts=ts, t0=None, gpd_params=gpd_params)  # type: ignore
+
+    def test_get_anomaly_threshold_with_valid_input(self):
+        ts = pd.Series(np.random.rand(100), index=pd.date_range("2020-01-01", periods=100))
+        t1 = 50
+        q = 0.90
+        anomaly_threshold = get_anomaly_threshold(ts=ts, t1=t1, q=q)
+
+        self.assertIsInstance(anomaly_threshold, float)
+        self.assertTrue(0 <= anomaly_threshold <= 1)
+
+    def test_get_anomaly_threshold_with_invalid_ts(self):
+        t1 = 50
+        q = 0.90
+
+        with self.assertRaises(TypeError):
+            get_anomaly_threshold(ts="not a series", t1=t1, q=q)
 
     def tearDown(self) -> None:
         return super().tearDown()

--- a/tests/test_peaks_over_threshold.py
+++ b/tests/test_peaks_over_threshold.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from anomalytics import get_anomaly_score, get_exceedance_peaks_over_threshold
+from anomalytics import get_anomaly, get_anomaly_score, get_exceedance_peaks_over_threshold
 from anomalytics.stats import get_anomaly_threshold, get_threshold_peaks_over_threshold
 
 
@@ -13,6 +13,7 @@ class TestPeaksOverThreshold(unittest.TestCase):
             data=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], index=pd.date_range(start="2023-01-01", periods=10)
         )
         self.sample_2_ts = pd.Series(np.random.rand(100), index=pd.date_range(start="2023-01-01", periods=100))
+        self.sample_3_ts = pd.Series(np.random.rand(100) * 2, index=pd.date_range("2020-01-01", periods=100))
 
     def test_calculate_threshold_for_high_anomaly_type(self):
         pot_threshold = get_threshold_peaks_over_threshold(ts=self.sample_1_ts, t0=3, anomaly_type="high", q=0.90)
@@ -61,14 +62,13 @@ class TestPeaksOverThreshold(unittest.TestCase):
             get_exceedance_peaks_over_threshold(ts=self.sample_2_ts, t0=None, anomaly_type="high", q=0.90)  # type: ignore
 
     def test_fit_exceedance_with_valid_input(self):
-        ts = pd.Series(np.random.rand(100) * 2, index=pd.date_range("2020-01-01", periods=100))
         t0 = 10
         gpd_params: dict = {}
-        exceedances = get_exceedance_peaks_over_threshold(ts=ts, t0=t0, anomaly_type="high", q=0.9)
+        exceedances = get_exceedance_peaks_over_threshold(ts=self.sample_3_ts, t0=t0, anomaly_type="high", q=0.9)
         anomaly_scores = get_anomaly_score(ts=exceedances, t0=t0, gpd_params=gpd_params)
 
         self.assertIsInstance(anomaly_scores, pd.Series)
-        self.assertEqual(len(anomaly_scores), len(ts.values) - t0)
+        self.assertEqual(len(anomaly_scores), len(self.sample_3_ts.values) - t0)
         self.assertTrue(all(isinstance(gpd_params[i], dict) for i in gpd_params))
 
     def test_fit_exceedance_with_invalid_ts(self):
@@ -79,17 +79,15 @@ class TestPeaksOverThreshold(unittest.TestCase):
             get_anomaly_score(ts="not a series", t0=t0, gpd_params=gpd_params)
 
     def test_fit_exceedance_with_invalid_t0(self):
-        ts = pd.Series(np.random.rand(100) * 2, index=pd.date_range("2020-01-01", periods=100))
         gpd_params: dict = {}
 
         with self.assertRaises(ValueError):
-            get_anomaly_score(ts=ts, t0=None, gpd_params=gpd_params)  # type: ignore
+            get_anomaly_score(ts=self.sample_3_ts, t0=None, gpd_params=gpd_params)  # type: ignore
 
     def test_get_anomaly_threshold_with_valid_input(self):
-        ts = pd.Series(np.random.rand(100), index=pd.date_range("2020-01-01", periods=100))
         t1 = 50
         q = 0.90
-        anomaly_threshold = get_anomaly_threshold(ts=ts, t1=t1, q=q)
+        anomaly_threshold = get_anomaly_threshold(ts=self.sample_2_ts, t1=t1, q=q)
 
         self.assertIsInstance(anomaly_threshold, float)
         self.assertTrue(0 <= anomaly_threshold <= 1)
@@ -113,6 +111,26 @@ class TestPeaksOverThreshold(unittest.TestCase):
         anomaly_threshold = get_anomaly_threshold(ts=ts, t1=t1, q=q)
 
         self.assertEqual(anomaly_threshold, expected_anomaly_threshold)
+
+    def test_get_anomaly_with_valid_input(self):
+        self.sample_2_ts.iloc[75:] = self.sample_2_ts.iloc[75:] * 5
+
+        t1 = 50
+        q = 0.90
+        anomalies = get_anomaly(ts=self.sample_2_ts, t1=t1, q=q)
+
+        self.assertIsInstance(anomalies, pd.Series)
+
+        expected_anomalies = self.sample_2_ts.iloc[t1:] > get_anomaly_threshold(ts=self.sample_2_ts, t1=t1, q=q)
+
+        self.assertTrue((anomalies == expected_anomalies).all())
+
+    def test_get_anomaly_with_invalid_ts(self):
+        t1 = 50
+        q = 0.90
+
+        with self.assertRaises(TypeError):
+            get_anomaly(ts="not a series", t1=t1, q=q)
 
     def tearDown(self) -> None:
         return super().tearDown()


### PR DESCRIPTION
- [X] Implement `numpy.quantile()` in `get_anomaly_threshold()` to calculate the anomaly threshold. The input is all anomaly scores from `t1` time window.
- [X] Implement `get_anomaly()` to execute `get_anomaly_threshold()` and use it to locate anomalies in the `t2` time window.
- [X] Create unit test to ensure no corner cases can be used to execute all functions and that the quantile function is behaving correctly.

 closes #9 